### PR TITLE
Fix shorthand function signature

### DIFF
--- a/index.glsl
+++ b/index.glsl
@@ -33,7 +33,7 @@ vec3 halftone(vec3 texcolor, vec2 st, float frequency) {
   return mix(rgbscreen, black, 0.85*k + 0.3*n);
 }
 
-vec3 halftone(vec3 texcolor, vec2 st, float frequency) {
+vec3 halftone(vec3 texcolor, vec2 st) {
   return halftone(texcolor, st, 30.0);
 }
 


### PR DESCRIPTION
Previously still included the `frequency` parameter from the original definition, which was causing a shader error on use:

```
'halftone_1_5' : function already has a body
```

Thanks! :)
